### PR TITLE
Fixed mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ alerty.prompt(
 |----|----|-------|-----------|
 |title|string|''|title of dialog|
 |okLabel|string|确定|ok button text|
-|okLabel|string|取消|cancel button text|
+|cancelLabel|string|取消|cancel button text|
 
 ----------
 
@@ -143,7 +143,7 @@ alerty.prompt(
 |----|----|-------|-----------|
 |title|string|''|title of dialog|
 |okLabel|string|确定|ok button text|
-|okLabel|string|取消|cancel button text|
+|cancelLabel|string|取消|cancel button text|
 |inputType|string|'text'|input type, such as 'password', 'email'|
 |inputPlaceholder|'text'|''|input placeholder text|
 |inputValue|'text'|''|default input value|


### PR DESCRIPTION
Confirm/prompt option tables have two `okLabel`-s in them. Changed one of the `okLabel`-s to `cancelLabel` for both tables.